### PR TITLE
Use -F so tail follows filename instead of inode.

### DIFF
--- a/files/bin/start-cron.sh
+++ b/files/bin/start-cron.sh
@@ -4,4 +4,4 @@
 rsyslogd
 cron
 touch /var/log/cron.log
-tail -f /var/log/syslog /var/log/cron.log
+tail -F /var/log/syslog /var/log/cron.log


### PR DESCRIPTION
This may not be an issue in quay.io docker base image, but I encountered a problem on another ubuntu based image following this general strategy. The docker logs command stops working after /var/log/syslog is rotated. 

See http://unix.stackexchange.com/questions/22698/how-to-do-a-tail-f-of-log-rotated-files
