### PR TITLE
Install to user cron rather tha overwriting /etc/crontab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM quay.io/aptible/ubuntu:14.04
 RUN apt-get -y install rsyslog
 
 # Add these lines to your own Dockerfile
-ADD files/etc/crontab /etc/crontab
+ADD files/crontab /app/crontab
+RUN crontab /app/crontab
 ADD files/bin/start-cron.sh /usr/bin/start-cron.sh
 RUN chmod +x /usr/bin/start-cron.sh
 RUN touch /var/log/cron.log

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ The example will print "aptible/docker-cron-example" once every minute.
 To include within an Aptible app, copy the following 5 body lines of the Dockerfile to your own Dockerfile:
 
     RUN apt-get -y install rsyslog
-    ADD files/etc/crontab /etc/crontab
+    ADD files/crontab /app/crontab
+    RUN crontab /app/crontab
     ADD files/bin/start-cron.sh /usr/bin/start-cron.sh
     RUN chmod +x /usr/bin/start-cron.sh
     RUN touch /var/log/cron.log
 
 * Installs ```rsyslog``` http://www.rsyslog.com/
-* Copies ```crontab``` from repo/app data to Docker
+* Copies ```crontab``` file from repo/app data to Docker and installs to user's ```crontab```
 * Copies ```start-cron.sh``` from repo/app data to Docker
 * Adjusts permissions
 * Creates log file at ```/var/log/cron.log```

--- a/files/crontab
+++ b/files/crontab
@@ -1,0 +1,1 @@
+* * * * * echo aptible/docker-cron-example >> /var/log/cron.log 2>&1

--- a/files/etc/crontab
+++ b/files/etc/crontab
@@ -1,1 +1,0 @@
-* * * * * root echo aptible/docker-cron-example >> /var/log/cron.log 2>&1


### PR DESCRIPTION
It's very possible that when customers overwrite their system crontab, they are also overwriting the permissions to something too permissive.  When this happens, `cron` fails to run with the following error: `(​*system*​) INSECURE MODE (group/other writable) (/etc/crontab)`. We could account for this by adding `RUN chmod 600 /etc/crontab` to our Dockerfile example here, but instead it seems better to just update the example to install a user crontab rather than overwriting the system crontab.  

---

cc @krallin @fancyremarker 
